### PR TITLE
Fix package_name in package resource.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,7 +22,7 @@ class etcd::install(
     $package_name     = $::etcd::package_name,
   ) inherits etcd {
   if $manage_package {
-    package { 'etcd':
+    package { '$package_name':
       ensure => $package_ensure,
       name   => $package_name,
     }


### PR DESCRIPTION
Install.pp has a hardcoded package resource title, which causes the following error when using a custom package-name. 

`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Invalid relationship: File[/etc/default/etcd.conf] { require => Package[etcd-server] }, because Package[etcd-server] doesn't seem to be in the catalog
`

